### PR TITLE
Fixing CMakeLists.txt and package.xml for raptor_dbw_can.

### DIFF
--- a/raptor_dbw_can/CMakeLists.txt
+++ b/raptor_dbw_can/CMakeLists.txt
@@ -16,30 +16,17 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 # find dependencies
-find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_components REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(nodelet REQUIRED)
-find_package(geometry_msgs REQUIRED)
-find_package(raptor_dbw_msgs REQUIRED)
-find_package(sensor_msgs REQUIRED)
-find_package(can_msgs REQUIRED)
-find_package(can_dbc_parser REQUIRED)
-find_package(pdu_msgs REQUIRED)
 
-ament_auto_add_library(
-  raptor_dbw_can src/DbwNode.cpp
+ament_auto_add_executable(${PROJECT_NAME}_node
   src/node.cpp
-)
-
-ament_auto_add_executable(
-  raptor_dbw_can_node src/node.cpp
   src/DbwNode.cpp
-  
 )
 
-ament_package()
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_auto_package()

--- a/raptor_dbw_can/package.xml
+++ b/raptor_dbw_can/package.xml
@@ -10,9 +10,7 @@
 
   <license>BSD</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
 
   <depend>rclcpp</depend>
   <depend>raptor_dbw_msgs</depend>


### PR DESCRIPTION
Notes from these changes:
- `ament_auto_find_build_dependencies()` removes the need to `find_package` any dependencies except `ament_cmake_auto`
- Adding the files as a library is only necessary if you're using them as [Composable Nodes](https://index.ros.org/doc/ros2/Tutorials/Composition/) (which isn't really required)
- `ament_package()` just creates the package and registers it in the index. `ament_auto_package()` does a bunch more including installing the executables and libraries added with the `ament_auto_` macros - this is why you were unable to run the executable from a launch file.
- Having a dependency on `ament_cmake_auto` implies a dependency on `ament_cmake`