### PR TITLE
Add Joy package explicit dependency.

### DIFF
--- a/raptor_dbw_joystick/package.xml
+++ b/raptor_dbw_joystick/package.xml
@@ -16,6 +16,7 @@
   <depend>raptor_dbw_msgs</depend>
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
+  <depend>joy</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Add Joy dependency to package.xml for `rosdep` workspace resolution. Notice that rosdep keys are parsed explicitly from package.xml.