### PR TITLE
Humble update

### DIFF
--- a/raptor_dbw_can/src/raptor_dbw_can_node.cpp
+++ b/raptor_dbw_can/src/raptor_dbw_can_node.cpp
@@ -39,9 +39,9 @@ int main(int argc, char ** argv)
 
   // Get parameter values
   auto temp = std::make_shared<rclcpp::Node>("get_dbw_params_node", options);
-  temp->declare_parameter("dbw_dbc_file");
-  temp->declare_parameter("max_steer_angle");
-
+  temp->declare_parameter("dbw_dbc_file", rclcpp::PARAMETER_STRING);
+  temp->declare_parameter("max_steer_angle", rclcpp::PARAMETER_DOUBLE);
+  
   std::string n_dbw_dbc_file = temp->get_parameter("dbw_dbc_file").as_string();
   float n_max_steer_angle = temp->get_parameter("max_steer_angle").as_double();
 

--- a/raptor_dbw_joystick/src/raptor_dbw_joystick_node.cpp
+++ b/raptor_dbw_joystick/src/raptor_dbw_joystick_node.cpp
@@ -39,10 +39,10 @@ int main(int argc, char ** argv)
 
   // Get parameter values
   auto temp = std::make_shared<rclcpp::Node>("get_joy_params_node", options);
-  temp->declare_parameter("ignore");
-  temp->declare_parameter("enable");
-  temp->declare_parameter("svel");
-  temp->declare_parameter("max_steer_angle");
+  temp->declare_parameter("ignore", rclcpp::PARAMETER_BOOL);
+  temp->declare_parameter("enable", rclcpp::PARAMETER_BOOL);
+  temp->declare_parameter("svel", rclcpp::PARAMETER_DOUBLE);
+  temp->declare_parameter("max_steer_angle", rclcpp::PARAMETER_DOUBLE);
 
   bool n_ignore = temp->get_parameter("ignore").as_bool();
   bool n_enable = temp->get_parameter("enable").as_bool();


### PR DESCRIPTION
Hi,
I've discovered in the upgrade to Humble ROS that declare_parameter needs type information like so:

- declare_parameter("ignore", rclcpp::PARAMETER_BOOL)

This does need to be created as a branch for humble however.