### PR TITLE
`uint32_t` not recognised on modern compilers without include

### DIFF
--- a/can_dbc_parser/include/can_dbc_parser/DbcSignal.hpp
+++ b/can_dbc_parser/include/can_dbc_parser/DbcSignal.hpp
@@ -29,6 +29,7 @@
 #ifndef CAN_DBC_PARSER__DBCSIGNAL_HPP_
 #define CAN_DBC_PARSER__DBCSIGNAL_HPP_
 
+#include <cstdint>
 #include <string>
 
 namespace NewEagle

--- a/can_dbc_parser/include/can_dbc_parser/LineParser.hpp
+++ b/can_dbc_parser/include/can_dbc_parser/LineParser.hpp
@@ -30,6 +30,7 @@
 #define CAN_DBC_PARSER__LINEPARSER_HPP_
 
 #include <cctype>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 


### PR DESCRIPTION
Way ahead of myself with the compiler, but this will fix future ROS2 versions.

Foxy still works as this include was actually already supposed to be there.