### PR TITLE
Fix VIN Publisher

### DIFF
--- a/raptor_dbw_can/src/raptor_dbw_can.cpp
+++ b/raptor_dbw_can/src/raptor_dbw_can.cpp
@@ -598,9 +598,9 @@ void RaptorDbwCAN::recvVinRpt(const Frame::SharedPtr msg)
       vin_.push_back(message->GetSignal("DBW_VinDigit_15")->GetResult());
       vin_.push_back(message->GetSignal("DBW_VinDigit_16")->GetResult());
       vin_.push_back(message->GetSignal("DBW_VinDigit_17")->GetResult());
+    }
       String msg; msg.data = vin_;
       pub_vin_->publish(msg);
-    }
   }
 }
 


### PR DESCRIPTION
### Fix VIN Publisher

This Pull Request proposes a fix to Issue #19.

We observed that the VIN was not being published over ROS 2 despite the CAN message successfully being transmitted by New Eagle Raptor Control Module. We also verified that the CAN message was successfully being received and read over Raptor-CAN.

After some debugging, we found that the [raptor_dbw_can.cpp](https://github.com/NewEagleRaptor/raptor-dbw-ros2/blob/e7a4169ffcad3f88a69b406286436b7d1ab231ce/raptor_dbw_can/src/raptor_dbw_can.cpp#L601-L602) has a bug that would prevent the ROS 2 message from being published in `VIN_MUX_VIN0` and `VIN_MUX_VIN1` states of the `DBW_VinMultiplexor`.

We have fixed this bug and tested successful reception of the VIN over the ROS 2 topic `/raptor_dbw_interface/vin`.

**Tested With:**
- RCM-58NN-112-2202
- Raptor-Cal 2023b_2.0.13564
- Raptor-CAN 2019a_1.0.10474
- ROS 2 Humble Hawksbill
- Ubuntu 22.04